### PR TITLE
Fixed  - YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated issue

### DIFF
--- a/faicon/models.py
+++ b/faicon/models.py
@@ -20,7 +20,7 @@ def get_icon_list():
             check FAICON_YAML_FILE setting.".format(YAML_FILE)
         )
     with open(file, 'r', encoding='utf-8') as stream:
-        data_loaded = yaml.load(stream)
+        data_loaded = yaml.load(stream, Loader=yaml.FullLoader)
     return data_loaded
 
 


### PR DESCRIPTION
I have fixed the warning "YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated". Please check. Thanks